### PR TITLE
Fix type piracy

### DIFF
--- a/src/UDEComponents.jl
+++ b/src/UDEComponents.jl
@@ -11,7 +11,6 @@ using ComponentArrays: ComponentArray
 export create_ude_component, multi_layer_feed_forward
 
 include("utils.jl")
-include("hacks.jl") # this should be removed / upstreamed
 
 """
     create_ude_component(n_input = 1, n_output = 1;
@@ -40,6 +39,10 @@ function create_ude_component(n_input = 1,
     @named ude_comp = ODESystem(
         eqs, t_nounits, [], [p, T], systems = [input, output])
     return ude_comp
+end
+
+function lazyconvert(T, x::Symbolics.Arr)
+    Symbolics.array_term(convert, T, x, size = size(x))
 end
 
 end

--- a/src/hacks.jl
+++ b/src/hacks.jl
@@ -1,4 +1,0 @@
-lazyconvert(x, y) = convert(x, y)
-lazyconvert(x, y::Symbolics.Arr) = Symbolics.array_term(convert, x, y)
-Symbolics.propagate_ndims(::typeof(convert), x, y) = ndims(y)
-Symbolics.propagate_shape(::typeof(convert), x, y) = Symbolics.shape(y)

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -7,8 +7,7 @@ using JET
     Aqua.find_persistent_tasks_deps(UDEComponents)
     Aqua.test_ambiguities(UDEComponents, recursive = false)
     Aqua.test_deps_compat(UDEComponents)
-    # TODO: fix type piracy in propagate_ndims and propagate_shape
-    Aqua.test_piracies(UDEComponents, broken = true)
+    Aqua.test_piracies(UDEComponents)
     Aqua.test_project_extras(UDEComponents)
     Aqua.test_stale_deps(UDEComponents, ignore = Symbol[])
     Aqua.test_unbound_args(UDEComponents)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] ~All documentation related to code changes were updated~ no docs yet
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] ~Any new documentation only uses public API~ no docs yet
  
## Additional context

I somehow missed that `Symbolics.array_term` had a `size` keyword argument. :sweat_smile: 